### PR TITLE
Legg til NullstillTestdataTestRoute for sletting av testdata i dev-gcp

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# Copilot Instructions for medlemskap-saga
+
+## Build & Test
+
+```bash
+# Build fat JAR (shadowJar)
+./gradlew shadowJar
+
+# Run all tests (requires Docker for TestContainers)
+./gradlew test
+
+# Run a single test class
+./gradlew test --tests "no.nav.medlemskap.saga.persistence.RepositoryTests"
+
+# Run a single test method
+./gradlew test --tests "no.nav.medlemskap.saga.persistence.RepositoryTests.lagre medlemskap vurdering"
+```
+
+JVM target is 21. Tests use JUnit 5 with TestContainers (PostgreSQL). Docker must be running.
+
+## Architecture
+
+This is a NAV microservice (Kotlin/Ktor 3, deployed on NAIS/GKE) that persists membership assessments (vurderinger). It has two input channels and two storage targets:
+
+**Input:**
+- Kafka consumer on topic `medlemskap.medlemskap-vurdert` — main ingestion path
+- REST API for queries and manual operations
+
+**Dual storage pattern — every vurdering is stored twice:**
+1. `vurdering` table — raw JSON (JSONB), used for lookups by fnr/soknadId/period
+2. `vurdering_analyse` table — normalized columns extracted from the JSON, used for CSV export and analysis
+
+The Kafka flow: `Consumer.flow()` → `SagaService.handle()` → stores to both tables → commits offset.
+
+**REST routes:**
+- `SagaRoutes` — `/findVureringerByFnr`, `/flexvurdering`, `/vurdering` (query vurderinger)
+- `AnalyseRoute` — `/analyse/hentUttrekk/{YYYYMM}` (generates CSV, uploads to GCS bucket)
+- `NullstillTestdataTestRoute` — `/test/slett-vurdering` (dev-gcp only, deletes test data)
+- `NaisRoutes` — `/isAlive`, `/isReady`, `/metrics`
+
+**Key integrations:**
+- PostgreSQL via HikariCP + kotliquery (queries) and raw JDBC (streaming CSV)
+- Flyway for migrations (`src/main/resources/db/migration/`, V1–V14)
+- Google Cloud Storage for CSV export files
+- Azure AD JWT authentication on all business routes
+
+## Conventions
+
+- **Language:** The codebase and domain terminology is in Norwegian (vurdering = assessment, fnr = fødselsnummer/national ID, ytelse = benefit type, svar = answer). Commit messages and comments use Norwegian.
+- **Entry point:** `no.nav.medlemskap.saga.ApplicationKt.main()` — starts Flyway migration, Kafka consumer flow in GlobalScope, then Ktor HTTP server on port 8080.
+- **Configuration:** Environment variables accessed via `System.getenv()` typed as `Environment = Map<String, String>`. The `Configuration` class uses `natpryce/konfig` with `".configProperty()"` extension. Key env vars: `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`, `KAFKA_BROKERS`, `GCP_BUCKET_NAME`, `AZURE_APP_CLIENT_ID`.
+- **Domain enums:** `Svar` (JA, NEI, UAVKLART), `Ytelse` (SYKEPENGER, BARNE_BRILLER, LOVME_GCP).
+- **Period filtering:** `objectMapper.kt` contains complex period-matching logic with day tolerances (16/21 days). Understand `begynnerIPerioden()`, `erInnenforEllerSammePeriodeMedDagerDiffFør()`, and related functions before modifying query logic.
+- **Database:** Migrations are sequential (V1–V14). The `vurdering` table stores fnr inside JSONB at path `json->'datagrunnlag'->>'fnr'` with a GIN index. Never add a plain fnr column — queries use the JSON path.
+- **Testing:** Repository tests extend `AbstractContainerDatabaseTest` and use a shared PostgreSQL TestContainer. Test JSON fixtures live in `src/test/resources/`. There are no Kafka integration tests.
+- **CSV streaming:** `VurderingForAnalyseRepository.hentOgSkrivVurderinger()` uses raw JDBC with `fetchSize=1000` for memory-efficient streaming. Don't convert this to kotliquery — it needs cursor-based streaming.
+- **Tag extraction:** `utled_vurderingstagger/` package extracts structured tags from raw vurdering JSON for the analyse table. Each brukerinput field has a corresponding `*Tag` data class.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ medlemskap-saga tilbyr 2 API-er.
 
 1. SagaRoute - for lagring av vurderinger og vurderinger for analyse
 2. AnalyseRoute - for henting av vurderinger og lagre til CSV-fil i Google Cloud Storage (GCS)
+3. NullstillTestdataTestRoute - for sletting av testdata (kun tilgjengelig i dev-gcp)
 
 ## SagaRoute - Lagring av vurderinger
 
@@ -70,6 +71,37 @@ kan også benyttes i test ved å konfigurere en Trygdeetaten-bruker som brukes t
 
 curl -X POST  https://medlemskap-vurdering.intern.dev.nav.no/analyse/hentUttrekk/202510 \
 -H "Authorization: Bearer DITT_TOKEN_HER"
+
+## NullstillTestdataTestRoute - Sletting av testdata (kun dev-gcp)
+
+| Endepunkt                                                                   | Miljø   |
+|-----------------------------------------------------------------------------|---------|
+| POST https://medlemskap-vurdering.intern.dev.nav.no/test/slett-vurdering    | dev-gcp |
+
+### Formål
+Endepunktet sletter alle vurderinger og analyse-rader for et gitt fødselsnummer fra begge tabellene (`vurdering` og `vurdering_analyse`). 
+Kun tilgjengelig i dev-gcp for nullstilling av testdata.
+
+### Eksempel på kall
+
+Kallet er en POST mot url definert over
+
+```
+curl -X POST https://medlemskap-vurdering.intern.dev.nav.no/test/slett-vurdering \
+  -H "Authorization: Bearer DITT_TOKEN_HER" \
+  -H "Content-Type: application/json" \
+  -d '{"fnr": "12345678912"}'
+```
+
+### Eksempel på respons
+
+```json
+{
+  "fnr": "12345678912",
+  "slettetVurderinger": 3,
+  "slettetVurderingAnalyse": 3
+}
+```
 
 # Testing
 

--- a/src/main/kotlin/no/nav/medlemskap/saga/nais/HttpServer.kt
+++ b/src/main/kotlin/no/nav/medlemskap/saga/nais/HttpServer.kt
@@ -30,6 +30,7 @@ import no.nav.medlemskap.saga.persistence.VurderingForAnalyseRepositoryImpl
 import no.nav.medlemskap.saga.rest.objectMapper
 import no.nav.medlemskap.saga.rest.sagaRoutes
 import no.nav.medlemskap.saga.rest.analyseRoute
+import no.nav.medlemskap.saga.rest.nullstillTestdataTestRoute
 import no.nav.medlemskap.saga.service.SagaService
 import no.nav.medlemskap.saga.service.AnalyseService
 import java.io.Writer
@@ -47,6 +48,7 @@ fun createHttpServer(consumeJob: Job) = embeddedServer(Netty, port = 8080) {
 
     val analyseService = AnalyseService(VurderingForAnalyseRepositoryImpl(DataSourceBuilder(System.getenv()).getDataSource()))
     val storage = StorageOptions.getDefaultInstance().service
+    val isDevGcp = configuration.cluster == "dev-gcp"
 
         install(CallId) {
             header(MDC_CALL_ID)
@@ -85,6 +87,12 @@ fun createHttpServer(consumeJob: Job) = embeddedServer(Netty, port = 8080) {
             naisRoutes(consumeJob)
             sagaRoutes(service)
             analyseRoute(analyseService, storage)
+            if (isDevGcp) {
+                nullstillTestdataTestRoute(
+                    PostgresMedlemskapVurdertRepository(DataSourceBuilder(System.getenv()).getDataSource()),
+                    VurderingForAnalyseRepositoryImpl(DataSourceBuilder(System.getenv()).getDataSource())
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/medlemskap/saga/persistence/MedlemskapVurdertRepository.kt
+++ b/src/main/kotlin/no/nav/medlemskap/saga/persistence/MedlemskapVurdertRepository.kt
@@ -12,6 +12,7 @@ interface MedlemskapVurdertRepository {
 
     fun lagreVurdering(id: String, eventDate: Date, json: String,ytelse:String)
     fun finnVurderingMedFnr(fnr: String): List<VurderingDao>
+    fun slettVurderingerForFnr(fnr: String): Int
 }
 
 class PostgresMedlemskapVurdertRepository(val dataSource: DataSource) : MedlemskapVurdertRepository {
@@ -19,6 +20,7 @@ class PostgresMedlemskapVurdertRepository(val dataSource: DataSource) : Medlemsk
     val SELECT_ALL = "select * from vurdering"
     val FIND_BY_SOKNAD_ID = "select * from vurdering where soknadId = ?"
     val FIND_BY_FNR = "select * from vurdering where json->'datagrunnlag'->>'fnr' =?"
+    val DELETE_BY_FNR = "DELETE FROM vurdering WHERE json->'datagrunnlag'->>'fnr' = ?"
 
     override fun finnVurdering(soknadId: String): List<VurderingDao> {
 
@@ -49,6 +51,12 @@ class PostgresMedlemskapVurdertRepository(val dataSource: DataSource) : Medlemsk
                 it.run(queryOf(INSERT_VURDERING, id, eventDate, json,ytelse).asExecute)
             }
 
+        }
+    }
+
+    override fun slettVurderingerForFnr(fnr: String): Int {
+        return using(sessionOf(dataSource)) { session ->
+            session.run(queryOf(DELETE_BY_FNR, fnr).asUpdate)
         }
     }
 

--- a/src/main/kotlin/no/nav/medlemskap/saga/persistence/VurderingForAnalyseRepository.kt
+++ b/src/main/kotlin/no/nav/medlemskap/saga/persistence/VurderingForAnalyseRepository.kt
@@ -49,6 +49,7 @@ interface VurderingForAnalyseRepository {
     )
     fun hentVurderingerForAnalyse(førsteDag: LocalDate, sisteDag: LocalDate): List<VurderingForAnalyseDAO>
     fun hentOgSkrivVurderinger(førsteDag: LocalDate, sisteDag: LocalDate, outputStream: OutputStream)
+    fun slettVurderingerForAnalyseForFnr(fnr: String): Int
 
 }
 
@@ -214,6 +215,7 @@ class VurderingForAnalyseRepositoryImpl(val dataSource: DataSource) : VurderingF
     }
 
     val HENT_VURDERINGER_FOR_ANALYSE_FOR_PERIODE = "SELECT DISTINCT * FROM vurdering_analyse WHERE dato BETWEEN ? AND ?"
+    val DELETE_ANALYSE_BY_FNR = "DELETE FROM vurdering_analyse WHERE fnr = ?"
 
     override fun hentVurderingerForAnalyse(førsteDag: LocalDate, sisteDag: LocalDate): List<VurderingForAnalyseDAO> {
         return using(sessionOf(dataSource)) {
@@ -223,6 +225,12 @@ class VurderingForAnalyseRepositoryImpl(val dataSource: DataSource) : VurderingF
                         .map(tilVurderingForAnalyseDAO)
                         .asList
                 )
+        }
+    }
+
+    override fun slettVurderingerForAnalyseForFnr(fnr: String): Int {
+        return using(sessionOf(dataSource)) { session ->
+            session.run(queryOf(DELETE_ANALYSE_BY_FNR, fnr).asUpdate)
         }
     }
 

--- a/src/main/kotlin/no/nav/medlemskap/saga/rest/NullstillTestdataTestRoute.kt
+++ b/src/main/kotlin/no/nav/medlemskap/saga/rest/NullstillTestdataTestRoute.kt
@@ -19,7 +19,7 @@ fun Routing.nullstillTestdataTestRoute(
     medlemskapVurdertRepository: MedlemskapVurdertRepository,
     vurderingForAnalyseRepository: VurderingForAnalyseRepository
 ) {
-    route("/testdata") {
+    route("/test") {
         authenticate("azureAuth") {
             post("/slett-vurdering") {
                 val callerPrincipal: JWTPrincipal = call.authentication.principal()!!

--- a/src/main/kotlin/no/nav/medlemskap/saga/rest/NullstillTestdataTestRoute.kt
+++ b/src/main/kotlin/no/nav/medlemskap/saga/rest/NullstillTestdataTestRoute.kt
@@ -1,0 +1,61 @@
+package no.nav.medlemskap.saga.rest
+
+import io.ktor.http.*
+import io.ktor.server.auth.*
+import io.ktor.server.auth.jwt.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import mu.KotlinLogging
+import net.logstash.logback.argument.StructuredArguments.kv
+import no.nav.medlemskap.saga.persistence.MedlemskapVurdertRepository
+import no.nav.medlemskap.saga.persistence.VurderingForAnalyseRepository
+import org.slf4j.MarkerFactory
+
+private val logger = KotlinLogging.logger { }
+private val teamLogs = MarkerFactory.getMarker("TEAM_LOGS")
+
+fun Routing.nullstillTestdataTestRoute(
+    medlemskapVurdertRepository: MedlemskapVurdertRepository,
+    vurderingForAnalyseRepository: VurderingForAnalyseRepository
+) {
+    route("/testdata") {
+        authenticate("azureAuth") {
+            post("/slett-vurdering") {
+                val callerPrincipal: JWTPrincipal = call.authentication.principal()!!
+                val azp = callerPrincipal.payload.getClaim("azp").asString()
+                logger.info(teamLogs, "NullstillTestdataTestRoute: azp-claim i principal-token: {}", azp)
+
+                try {
+                    val request = call.receive<FnrRequest>()
+                    val fnr = request.fnr
+
+                    logger.info(teamLogs, "Sletter testdata for fnr", kv("fnr", fnr))
+
+                    val slettetVurderinger = medlemskapVurdertRepository.slettVurderingerForFnr(fnr)
+                    val slettetAnalyse = vurderingForAnalyseRepository.slettVurderingerForAnalyseForFnr(fnr)
+
+                    logger.info(
+                        teamLogs,
+                        "Testdata er slettet for fnr: slettet $slettetVurderinger vurderinger og $slettetAnalyse analyse-rader",
+                        kv("fnr", fnr),
+                        kv("slettetVurderinger", slettetVurderinger),
+                        kv("slettetAnalyse", slettetAnalyse)
+                    )
+
+                    call.respond(
+                        HttpStatusCode.OK,
+                        mapOf(
+                            "fnr" to fnr,
+                            "slettetVurderinger" to slettetVurderinger,
+                            "slettetVurderingAnalyse" to slettetAnalyse
+                        )
+                    )
+                } catch (t: Throwable) {
+                    logger.error("Feil ved sletting av testdata", t)
+                    call.respond(HttpStatusCode.InternalServerError, "Feil ved nullstilling av testdata: ${t.message}")
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/medlemskap/saga/persistence/NullstillTestdataTestRouteRepositoryTests.kt
+++ b/src/test/kotlin/no/nav/medlemskap/saga/persistence/NullstillTestdataTestRouteRepositoryTests.kt
@@ -1,0 +1,50 @@
+package no.nav.medlemskap.saga.persistence
+
+import no.nav.medlemskap.saga.rest.objectMapper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import java.util.*
+import java.util.logging.Level
+import java.util.logging.LogManager
+
+@org.testcontainers.junit.jupiter.Testcontainers
+class NullstillTestdataTestRouteRepositoryTests : AbstractContainerDatabaseTest() {
+    init {
+        LogManager.getLogManager().getLogger("").level = Level.OFF
+    }
+
+    companion object {
+        @Container
+        private val postgresqlContainer = MyPostgreSQLContainer("postgres:14")
+            .withDatabaseName("medlemskap")
+            .withUsername("postgres")
+            .withPassword("test")
+    }
+
+    @Test
+    fun `slettVurderingerForFnr sletter kun rader med gitt fnr`() {
+        val fileContent = this::class.java.classLoader.getResource("sampleVurdering_UAVKLART.json").readText(Charsets.UTF_8)
+        val ytelse = runCatching { objectMapper.readTree(fileContent).get("datagrunnlag").get("ytelse").asText() }.getOrElse { "UKJENT" }
+        val fnr = "23089039444"
+
+        postgresqlContainer.withUrlParam("user", postgresqlContainer.username)
+        postgresqlContainer.withUrlParam("password", postgresqlContainer.password)
+        val dsb = DataSourceBuilder(mapOf("DB_JDBC_URL" to postgresqlContainer.jdbcUrl))
+        dsb.migrate()
+        val repo = PostgresMedlemskapVurdertRepository(dsb.getDataSource())
+
+        repo.lagreVurdering(UUID.randomUUID().toString(), Date(), fileContent, ytelse)
+        repo.lagreVurdering(UUID.randomUUID().toString(), Date(), fileContent, ytelse)
+
+        val førSletting = repo.finnVurderingMedFnr(fnr)
+        assertTrue(førSletting.size >= 2, "Skal ha minst 2 vurderinger før sletting")
+
+        val slettet = repo.slettVurderingerForFnr(fnr)
+        assertTrue(slettet >= 2, "Skal ha slettet minst 2 rader")
+
+        val etterSletting = repo.finnVurderingMedFnr(fnr)
+        assertEquals(0, etterSletting.size, "Skal ikke ha noen vurderinger etter sletting")
+    }
+}


### PR DESCRIPTION
Ny route POST /testdata/slett-vurdering som sletter vurderinger og vurdering_analyse-rader basert på fnr. Routen er kun tilgjengelig i dev-gcp miljøet.

- Lagt til slettVurderingerForFnr i MedlemskapVurdertRepository
- Lagt til slettVurderingerForAnalyseForFnr i VurderingForAnalyseRepository
- Opprettet NullstillTestdataTestRoute med Azure AD-autentisering
- Registrert route i HttpServer kun når cluster == dev-gcp
- Lagt til repository-test for sletting